### PR TITLE
fix: remove node engine limitation

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
   "main": "dist/is-drm-supported.min.js",
   "private": false,
   "license": "MIT",
-  "engines": {
-    "node": ">=16.0.0 <17.0.0"
-  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Closes #5 

This limitation was intended to only affect developers of the package, not consumers. Removing it for now.