### PR TITLE
feat!: update playready key system checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ Tiny MSE video and audio DRM detection library.
 
 The package exports the following asynchronous methods:
 
-> isPlayreadySupported
+> isPlayreadyLegacySupported
 >
 > isPlayreadyChromecastSupported
 >
-> isPlayreadyRecommendedSupported
+> isPlayreadySupported
+>
+> isPlayreadyHardwareSupported
 >
 > isWidevineSupported
 >

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,22 +36,30 @@ const isMediaKeySupported = async (keySystem: TKeySystem): Promise<boolean> => {
   }
 };
 
-export const isPlayreadySupported = async (): Promise<boolean> => {
+export const isPlayreadyLegacySupported = async (): Promise<boolean> => {
   if (!navigator.requestMediaKeySystemAccess) return false;
 
   return isMediaKeySupported({ ks: "com.microsoft.playready" });
+};
+
+export const isPlayreadySupported = async (): Promise<boolean> => {
+  if (!navigator.requestMediaKeySystemAccess) return false;
+
+  return isMediaKeySupported({ ks: "com.microsoft.playready.recommendation" });
+};
+
+export const isPlayreadyHardwareSupported = async (): Promise<boolean> => {
+  if (!navigator.requestMediaKeySystemAccess) return false;
+
+  return isMediaKeySupported({
+    ks: "com.microsoft.playready.recommendation.3000",
+  });
 };
 
 export const isPlayreadyChromecastSupported = async (): Promise<boolean> => {
   if (!navigator.requestMediaKeySystemAccess) return false;
 
   return isMediaKeySupported({ ks: "com.chromecast.playready" });
-};
-
-export const isPlayreadyRecommendedSupported = async (): Promise<boolean> => {
-  if (!navigator.requestMediaKeySystemAccess) return false;
-
-  return isMediaKeySupported({ ks: "com.microsoft.playready.recommended" });
 };
 
 export const isWidevineSupported = async (): Promise<boolean> => {


### PR DESCRIPTION
Adds new playready key system checks:

isPlayreadyLegacySupported
isPlayreadySupported
isPlayreadyHardwareSupported

BREAKING CHANGE:

The original isPlayreadySupported has been renamed to isPlayreadyLegacySupported. The new isPlayreadySupported now checks com.microsoft.playready.recommendation.

com.microsoft.playready is deprecated by Microsoft.

https://learn.microsoft.com/en-us/playready/overview/key-system-strings